### PR TITLE
No longer issues indent warnings on empty lines.

### DIFF
--- a/kwsCheckIndent.cxx
+++ b/kwsCheckIndent.cxx
@@ -179,6 +179,7 @@ bool Parser::CheckIndent(IndentType itype,
   {
 	line_number++;
 	std::string line = clean_line(l) ;
+        if (line.empty()) continue;
     //std::cout<< is_directive(line) << " - " << line <<"\n";
 	int actual = get_indent(line,indent_char);
     if (is_directive(line))


### PR DESCRIPTION
This is a bug fix—it was complaining that empty lines should have positive indents to match the preceding non-empty line.